### PR TITLE
Fix `ffprobe` permissions

### DIFF
--- a/radarr.spec
+++ b/radarr.spec
@@ -118,6 +118,7 @@ install -D -m 0644 -p %{SOURCE10} %{buildroot}%{_unitdir}/%{name}.service
 install -D -m 0644 -p %{SOURCE11} %{buildroot}%{_prefix}/lib/firewalld/services/%{name}.xml
 
 find %{buildroot} -name "*.pdb" -delete
+find %{buildroot} -name "ffprobe" -exec chmod 0755 {} \;
 
 %pre
 getent group %{group} >/dev/null || groupadd -r %{group}


### PR DESCRIPTION
`ffprobe` is owned by root and can't be executed by the `radarr` user because of `740` permissions.
Change the permissions of `ffprobe` to `755`.